### PR TITLE
Troubleshoot CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-core ansible-lint --pre
+        run: pip3 install yamllint ansible-core ansible-lint
 
       - name: Lint code.
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install molecule[docker] --pre
+          pip3 install molecule --pre
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-core ansible-lint
+        run: pip3 install yamllint ansible-core ansible-lint --pre
 
       - name: Lint code.
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,7 @@ jobs:
 
       - name: Install test dependencies.
         run: |
-          pip3 install ansible --pre
           pip3 install molecule[docker] --pre
-          pip3 install docker --pre
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] docker --pre
+        run: pip3 install ansible molecule[docker] docker
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,10 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] docker
+        run: |
+          pip3 install ansible --pre
+          pip3 install molecule[docker] --pre
+          pip3 install docker --pre
 
       - name: Run Molecule tests.
         run: molecule test


### PR DESCRIPTION
This has failed last night:
https://github.com/aminvakil/ansible-role-docker-installation/actions/runs/1781433350
```
Run pip3 install ansible molecule[docker] docker --pre
Collecting ansible
  Downloading ansible-5.3.0.tar.gz (38.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 38.0/38.0 MB 42.9 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting molecule[docker]
  Downloading molecule-3.5.2-py3-none-any.whl (240 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 240.2/240.2 KB 58.0 MB/s eta 0:00:00
Collecting docker
  Downloading docker-5.0.3-py2.py3-none-any.whl (146 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 146.2/146.2 KB 46.9 MB/s eta 0:00:00
Collecting ansible-core~=2.12.2
  Downloading ansible-core-2.12.2.tar.gz (7.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.8/7.8 MB 48.1 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting cookiecutter>=1.7.3
  Downloading cookiecutter-1.7.3-py2.py3-none-any.whl (34 kB)
Collecting pluggy<2.0,>=0.7.1
  Downloading pluggy-1.0.0-py2.py3-none-any.whl (13 kB)
Collecting enrich>=1.2.5
  Downloading enrich-1.2.7-py3-none-any.whl (8.7 kB)
Collecting selinux
  Downloading selinux-0.2.1-py2.py3-none-any.whl (4.3 kB)
Collecting click<9,>=8.0
  Downloading click-8.0.3-py3-none-any.whl (97 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 97.5/97.5 KB 33.8 MB/s eta 0:00:00
Collecting rich>=9.5.1
  Downloading rich-11.1.0-py3-none-any.whl (216 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 216.5/216.5 KB 59.2 MB/s eta 0:00:00
Collecting ansible-compat>=0.5.0
  Downloading ansible_compat-1.0.0-py3-none-any.whl (16 kB)
Collecting cerberus!=1.3.3,!=1.3.4,>=1.3.1
  Downloading Cerberus-1.3.2.tar.gz (52 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 52.5/52.5 KB 21.9 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting Jinja2>=2.11.3
  Downloading Jinja2-3.0.3-py3-none-any.whl (133 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 133.6/133.6 KB 39.9 MB/s eta 0:00:00
Collecting paramiko<3,>=2.5.0
  Downloading paramiko-2.9.2-py2.py3-none-any.whl (210 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 210.5/210.5 KB 54.6 MB/s eta 0:00:00
Collecting PyYAML<6,>=5.1
  Downloading PyYAML-5.4.1.tar.gz (175 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 KB 52.2 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [46 lines of output]
      running egg_info
      writing lib3/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib3/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 130, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 162, in get_requires_for_build_wheel
          return self._get_build_requires(
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 143, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 158, in run_setup
          exec(compile(code, __file__, 'exec'), locals())
        File "setup.py", line 271, in <module>
          setup(
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/__init__.py", line 155, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 148, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 163, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 967, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 986, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 299, in run
          self.find_sources()
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 306, in find_sources
          mm.run()
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 541, in run
          self.add_defaults()
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 578, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 228, in add_defaults
          self._add_defaults_ext()
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 312, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "setup.py", line 201, in get_source_files
          self.cython_sources(ext.sources, ext)
        File "/tmp/pip-build-env-2kijzys6/overlay/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 103, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
Error: Process completed with exit code 1.
```